### PR TITLE
feat: add Firebase auth components

### DIFF
--- a/catalyst-itsm/apps/portal/src/authState.js
+++ b/catalyst-itsm/apps/portal/src/authState.js
@@ -1,0 +1,19 @@
+import { auth } from './firebaseConfig.js';
+import { onAuthStateChanged } from 'firebase/auth';
+
+let currentUser = null;
+const listeners = new Set();
+
+onAuthStateChanged(auth, (user) => {
+  currentUser = user;
+  listeners.forEach((cb) => cb(user));
+});
+
+export function getCurrentUser() {
+  return currentUser;
+}
+
+export function onUserChange(callback) {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+}

--- a/catalyst-itsm/apps/portal/src/login.js
+++ b/catalyst-itsm/apps/portal/src/login.js
@@ -1,0 +1,6 @@
+import { auth } from './firebaseConfig.js';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+
+export function login(email, password) {
+  return signInWithEmailAndPassword(auth, email, password);
+}

--- a/catalyst-itsm/apps/portal/src/signup.js
+++ b/catalyst-itsm/apps/portal/src/signup.js
@@ -1,0 +1,6 @@
+import { auth } from './firebaseConfig.js';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+
+export function signUp(email, password) {
+  return createUserWithEmailAndPassword(auth, email, password);
+}


### PR DESCRIPTION
## Summary
- add signup and login helpers using Firebase auth
- track current user globally via `onAuthStateChanged`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689a5ff7703c8323b06de53591ddc462