### PR TITLE
feat(portal): load tickets from Firestore with tenant support

### DIFF
--- a/catalyst-itsm/apps/portal/src/TicketList.js
+++ b/catalyst-itsm/apps/portal/src/TicketList.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+import { fetchTickets, listenToTickets } from "./ticketService.js";
+
+// Component that renders tickets for a tenant using Firestore queries
+export default function TicketList({ tenantId }) {
+  const [tickets, setTickets] = useState([]);
+
+  useEffect(() => {
+    // Initial fetch
+    fetchTickets(tenantId).then(setTickets);
+    // Realtime updates
+    const unsubscribe = listenToTickets(tenantId, setTickets);
+    return () => unsubscribe();
+  }, [tenantId]);
+
+  return (
+    <ul>
+      {tickets.map((t) => (
+        <li key={t.id}>{t.title || t.id}</li>
+      ))}
+    </ul>
+  );
+}

--- a/catalyst-itsm/apps/portal/src/ticketService.js
+++ b/catalyst-itsm/apps/portal/src/ticketService.js
@@ -1,0 +1,32 @@
+import { collection, doc, getDocs, onSnapshot, query, where, setDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "./firebaseConfig.js";
+
+// Fetch all tickets for a given tenant using getDocs
+export const fetchTickets = async (tenantId) => {
+  const q = query(collection(db, "tickets"), where("tenantId", "==", tenantId));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+};
+
+// Listen to realtime updates for tickets belonging to a tenant
+export const listenToTickets = (tenantId, callback) => {
+  const q = query(collection(db, "tickets"), where("tenantId", "==", tenantId));
+  return onSnapshot(q, (snapshot) => {
+    const tickets = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(tickets);
+  });
+};
+
+// Create a new ticket under tickets/{ticketId} with tenantId
+export const createTicket = async (ticketId, tenantId, data) => {
+  const ticketRef = doc(db, "tickets", ticketId);
+  await setDoc(ticketRef, { ...data, tenantId, createdAt: serverTimestamp() });
+  return ticketRef.id;
+};
+
+// Add a comment under tickets/{ticketId}/comments/{commentId} with tenantId
+export const addComment = async (ticketId, commentId, tenantId, data) => {
+  const commentRef = doc(db, "tickets", ticketId, "comments", commentId);
+  await setDoc(commentRef, { ...data, tenantId, createdAt: serverTimestamp() });
+  return commentRef.id;
+};


### PR DESCRIPTION
## Summary
- add Firestore-backed ticket service for fetching, listening and creating tickets/comments
- render tickets for a tenant from Firestore instead of hard-coded arrays

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5ffa68e48323b1e09e61d76be837