### PR TITLE
Configure Firebase hosting and Firestore rules

### DIFF
--- a/catalyst-itsm/README.md
+++ b/catalyst-itsm/README.md
@@ -1,0 +1,14 @@
+# Catalyst ITSM
+
+## Deployment
+
+1. Build the portal assets:
+   ```sh
+   pnpm --filter @catalyst/apps-portal build
+   ```
+2. Deploy to Firebase:
+   ```sh
+   firebase deploy
+   ```
+
+Firebase Hosting serves the built files from `apps/portal/build` and rewrites all routes to `index.html` to support the single-page app.

--- a/catalyst-itsm/firebase.json
+++ b/catalyst-itsm/firebase.json
@@ -1,0 +1,12 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "hosting": {
+    "public": "apps/portal/build",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ]
+  }
+}

--- a/catalyst-itsm/firestore.rules
+++ b/catalyst-itsm/firestore.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service cloud.firestore {
+  function isTenantMember(tenantId) {
+    return request.auth != null && request.auth.token.tenantId == tenantId;
+  }
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read: if isTenantMember(resource.data.tenantId);
+      allow write: if isTenantMember(request.resource.data.tenantId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add tenant-aware Firestore rules
- configure Firebase Hosting for apps/portal with SPA rewrites
- document portal build and Firebase deploy workflow

## Testing
- `pnpm lint`
- `pnpm --filter @catalyst/apps-portal build` *(fails: None of the selected packages has a "build" script)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ffc12e8832385c5712e1533de00